### PR TITLE
Add: support for routed local kavlan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ tmp/*
 hiera/
 # prevent conflict on xp5k cutomization
 config/
+xp.conf
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ total 242380
 
 ### Prerequisites : see http://capi5k.github.io/capi5k/
 
+## Prepare the deployment
+
+Create the file `xp.conf` into the `capi5k-openstack` directory with this content:
+
+    jobname         'the-name'
+    site            'the-site'
+    walltime        '2:00:00'
+    nodes           5
+
+Change the values according to what you want to deploy. 
+Be careful to not put a number of nodes less than 5. 
+
 ## Deploy
 
 * ``` xpm install ```

--- a/config/deploy/xp5k.rb
+++ b/config/deploy/xp5k.rb
@@ -3,24 +3,22 @@ require 'rubygems'
 require 'xp5k'
 require 'erb'
 
-# G5K global parameters
-set :site, ENV['site'] || "lyon"
-set :walltime, ENV['walltime'] || "3:00:00"
-set :subnet, ENV['subnet'] || "slash_18"
-set :jobname, ENV['jobname'] || "openstack"
-
-
 XP5K::Config.load
+
+XP5K::Config[:jobname]  ||= 'openstack'
+XP5K::Config[:site]     ||= 'lyon'
+XP5K::Config[:walltime] ||= '3:00:00'
+XP5K::Config[:nodes]    ||= 5
 
 $myxp = XP5K::XP.new(:logger => logger)
 
 $myxp.define_job({
-  :resources  => ["{type='kavlan'}/vlan=1, {virtual!='none'}/nodes=5, walltime=#{walltime}"],
-  :site       => "#{site}",
+  :resources  => ["{type='kavlan'}/vlan=1, {virtual!='none'}/nodes=#{XP5K::Config[:nodes]}, walltime=#{XP5K::Config[:walltime]}"],
+  :site       => "#{XP5K::Config[:site]}",
   :retry      => true,
   :goal       => "100%",
   :types      => ["deploy"],
-  :name       => "#{jobname}", 
+  :name       => "#{XP5K::Config[:jobname]}", 
   :roles      =>  [
     XP5K::Role.new({ :name => 'capi5k-init', :size => 5 }),
   ],
@@ -29,11 +27,11 @@ $myxp.define_job({
 })
 
 $myxp.define_deployment({
-  :site           => "#{site}",
+  :site           => "#{XP5K::Config[:site]}",
   :environment    => "ubuntu-x64-1204",
   :roles          => %w(capi5k-init),
   :key            => File.read("#{ssh_public}"), 
-  :vlan_from_job  => "#{jobname}",
+  :vlan_from_job  => "#{XP5K::Config[:jobname]}",
 })
 
 load "config/deploy/xp5k_common_tasks.rb"

--- a/config/deploy/xp5k.rb
+++ b/config/deploy/xp5k.rb
@@ -7,7 +7,7 @@ require 'erb'
 set :site, ENV['site'] || "lyon"
 set :walltime, ENV['walltime'] || "3:00:00"
 set :subnet, ENV['subnet'] || "slash_18"
-set :vlan, ENV['vlan'] || "13"
+set :jobname, ENV['jobname'] || "openstack"
 
 
 XP5K::Config.load
@@ -15,12 +15,12 @@ XP5K::Config.load
 $myxp = XP5K::XP.new(:logger => logger)
 
 $myxp.define_job({
-  :resources  => ["{type='kavlan-global'}/vlan=1, {virtual!='none'}/nodes=5, walltime=#{walltime}"],
+  :resources  => ["{type='kavlan'}/vlan=1, {virtual!='none'}/nodes=5, walltime=#{walltime}"],
   :site       => "#{site}",
   :retry      => true,
   :goal       => "100%",
   :types      => ["deploy"],
-  :name       => "openstack" , 
+  :name       => "#{jobname}", 
   :roles      =>  [
     XP5K::Role.new({ :name => 'capi5k-init', :size => 5 }),
   ],
@@ -32,8 +32,8 @@ $myxp.define_deployment({
   :site           => "#{site}",
   :environment    => "ubuntu-x64-1204",
   :roles          => %w(capi5k-init),
-  :vlan           => "#{vlan}",
   :key            => File.read("#{ssh_public}"), 
+  :vlan_from_job  => "#{jobname}",
 })
 
 load "config/deploy/xp5k_common_tasks.rb"

--- a/config/lib/vlan.rb
+++ b/config/lib/vlan.rb
@@ -1,7 +1,10 @@
-def translate_vlan(nodes, vlan = "-1")
-  if (vlan == "-1")
+def translate_vlan(nodes, jobname = "-1")
+  if (jobname == "-1")
     return nodes
   end
+
+  # get routed local vlan number using the jobname variable
+  vlan = $myxp.job_with_name("#{jobname}")['resources_by_type']['vlans'].first.to_i
 
   to_translate = nodes
   puts to_translate.inspect
@@ -10,7 +13,7 @@ def translate_vlan(nodes, vlan = "-1")
   end
   to_translate.map {|node|
     a = node.split('.')
-    a[0] = a[0]+"-kavlan-#{vlan}"
+    a[0] = a[0]+"-kavlan-"+vlan.to_s
     a.join('.')
   }
 end

--- a/exports/capi5k-puppetcluster/roles.rb
+++ b/exports/capi5k-puppetcluster/roles.rb
@@ -8,11 +8,11 @@
 #
 #
 def role_puppet_master
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').first, "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').first, "#{XP5K::Config[:jobname]}")
 end
 
 def role_puppet_clients
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{XP5K::Config[:jobname]}")
 end
 
 def puppet_version

--- a/exports/capi5k-puppetcluster/roles.rb
+++ b/exports/capi5k-puppetcluster/roles.rb
@@ -8,11 +8,11 @@
 #
 #
 def role_puppet_master
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').first, "#{vlan}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').first, "#{jobname}")
 end
 
 def role_puppet_clients
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{vlan}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{jobname}")
 end
 
 def puppet_version

--- a/recipe.rb
+++ b/recipe.rb
@@ -86,13 +86,13 @@ namespace :openstack do
       set :user, "#{g5k_user}"
 
       # get routed local vlan number using the jobname variable
-      vlan = $myxp.job_with_name("#{jobname}")['resources_by_type']['vlans'].first.to_i
+      vlan = $myxp.job_with_name("#{XP5K::Config[:jobname]}")['resources_by_type']['vlans'].first.to_i
 
       # build IP address a.b.c.d
       
       vlan_config = YAML::load_file("#{openstack_path}/vlan-config.yaml")
       a=vlan_config["a"].to_s + "."
-      b=vlan_config["b"]["#{site}"]
+      b=vlan_config["b"]["#{XP5K::Config[:site]}"]
       b=b+1 if vlan > 7 # see "c" part of IP addresses of KAVLAN-8 and KAVLAN-9
       b=b.to_s
       c=vlan_config["c"][vlan]
@@ -291,7 +291,7 @@ namespace :openstack do
       controllerAddress = capture "facter ipaddress"
 
       # get routed local vlan number using the jobname variable
-      vlan = $myxp.job_with_name("#{jobname}")['resources_by_type']['vlans'].first.to_i
+      vlan = $myxp.job_with_name("#{XP5K::Config[:jobname]}")['resources_by_type']['vlans'].first.to_i
       vlan_config = YAML::load_file("#{openstack_path}/vlan-config.yaml")
       # we choose a range of ips which doen't collide with any host of g5k 
       # see https://www.grid5000.fr/mediawiki/index.php/User:Lnussbaum/Network#KaVLAN

--- a/recipe.rb
+++ b/recipe.rb
@@ -92,7 +92,7 @@ namespace :openstack do
       
       vlan_config = YAML::load_file("#{openstack_path}/vlan-config.yaml")
       a=vlan_config["a"].to_s + "."
-      b=vlan_config["b"]["#{site}"]
+      b=vlan_config["b"]["#{XP5K::Config[:site]}"]
       b=b+1 if vlan > 7 # see "c" part of IP addresses of KAVLAN-8 and KAVLAN-9
       b=b.to_s
       c=vlan_config["c"][vlan]

--- a/recipe.rb
+++ b/recipe.rb
@@ -86,7 +86,7 @@ namespace :openstack do
       set :user, "#{g5k_user}"
 
       # get routed local vlan number using the jobname variable
-      vlan = $myxp.job_with_name("#{jobname}")['resources_by_type']['vlans'].first.to_i
+      vlan = $myxp.job_with_name("#{XP5K::Config[:jobname]}")['resources_by_type']['vlans'].first.to_i
 
       # build IP address a.b.c.d
       
@@ -291,7 +291,7 @@ namespace :openstack do
       controllerAddress = capture "facter ipaddress"
 
       # get routed local vlan number using the jobname variable
-      vlan = $myxp.job_with_name("#{jobname}")['resources_by_type']['vlans'].first.to_i
+      vlan = $myxp.job_with_name("#{XP5K::Config[:jobname]}")['resources_by_type']['vlans'].first.to_i
       vlan_config = YAML::load_file("#{openstack_path}/vlan-config.yaml")
       # we choose a range of ips which doen't collide with any host of g5k 
       # see https://www.grid5000.fr/mediawiki/index.php/User:Lnussbaum/Network#KaVLAN

--- a/roles.rb
+++ b/roles.rb
@@ -9,19 +9,19 @@
 #
 
 def role_controller
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{vlan}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{jobname}")
 end
 
 # TODO setting to another node seems to not validate a constraints when puppet agent runs
 def role_storage
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{vlan}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{jobname}")
 end
 
 def role_compute
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(3..-1), "#{vlan}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(3..-1), "#{jobname}")
 end
 
 def role_openstack
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{vlan}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{jobname}")
 end
 

--- a/roles.rb
+++ b/roles.rb
@@ -9,19 +9,19 @@
 #
 
 def role_controller
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{XP5K::Config[:jobname]}")
 end
 
 # TODO setting to another node seems to not validate a constraints when puppet agent runs
 def role_storage
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{XP5K::Config[:jobname]}")
 end
 
 def role_compute
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(3..-1), "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(3..-1), "#{XP5K::Config[:jobname]}")
 end
 
 def role_openstack
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{XP5K::Config[:jobname]}")
 end
 

--- a/roles_definition.rb
+++ b/roles_definition.rb
@@ -24,6 +24,6 @@ end
 
 
 role :frontend do
-  "#{site}"
+  "#{XP5K::Config[:site]}"
 end
 

--- a/vlan-config.yaml
+++ b/vlan-config.yaml
@@ -1,0 +1,33 @@
+##
+# Hash table to create IP addresses according to the routed local vlan used
+# the values are based on the table you can see on this page: 
+# https://www.grid5000.fr/mediawiki/index.php/Grid5000:Network#Routed_Local_Vlans
+#
+# IP: a.b.c.d
+---
+# "a" section
+a: 10
+# "b" section
+b:
+    bordeaux:   0
+    grenoble:   4
+    lille:      8
+    lyon:       12
+    nancy:      16
+    orsay:      20
+    rennes:     24
+    toulouse:   28
+    sophia:     32
+    reims:      36
+    luxembourg: 40
+    nantes:     44
+# "c" section
+c:
+    4: 0
+    5: 64
+    6: 128
+    7: 192
+    8: 0
+    9: 64
+# "d" section
+d: 0


### PR DESCRIPTION
This version of capi5k-openstack uses the routed local kavlans rather than the global ones. 
