### PR TITLE
Add: xp.conf support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ hiera/
 # prevent conflict on xp5k cutomization
 config/
 Gemfile.lock
-
+xp.conf

--- a/config/deploy/xp5k.rb
+++ b/config/deploy/xp5k.rb
@@ -3,39 +3,42 @@ require 'rubygems'
 require 'xp5k'
 require 'erb'
 
-# G5K global parameters
-set :site, ENV['site'] || "lyon"
-set :walltime, ENV['walltime'] || "3:00:00"
-set :subnet, ENV['subnet'] || "slash_18"
-set :jobname, ENV['jobname'] || "openstack"
-## vlantype values:
-# "kavlan"        - routed local vlan
-# "kavlan-global" - global vlan
-set :vlantype, ENV['vlantype'] || "kavlan"
-
+# Load ./xp.conf file
+#
 XP5K::Config.load
+
+# Defaults configuration
+#
+XP5K::Config[:jobname]    ||= 'openstack'
+XP5K::Config[:site]       ||= 'toulouse'
+XP5K::Config[:walltime]   ||= '1:00:00'
+XP5K::Config[:cluster]    ||= ''
+XP5K::Config[:vlantype]   ||= 'kavlan'
+XP5K::Config[:nodes]      ||= '3'
+
+cluster = "and cluster='" + XP5K::Config[:cluster] + "'" if !XP5K::Config[:cluster].empty?
 
 $myxp = XP5K::XP.new(:logger => logger)
 
 $myxp.define_job({
-  :resources  => ["{type='#{vlantype}'}/vlan=1, {virtual!='none'}/nodes=5, walltime=#{walltime}"],
-  :site       => "#{site}",
+  :resources  => ["{type='#{XP5K::Config[:vlantype]}'}/vlan=1, {virtual!='none' #{cluster}}/nodes=#{XP5K::Config[:nodes]}, walltime=#{XP5K::Config[:walltime]}"],
+  :site       => "#{XP5K::Config[:site]}",
   :retry      => true,
   :goal       => "100%",
   :types      => ["deploy"],
-  :name       => "#{jobname}" ,
+  :name       => "#{XP5K::Config[:jobname]}" ,
   :roles      =>  [
-    XP5K::Role.new({ :name => 'capi5k-init', :size => 5 }),
+    XP5K::Role.new({ :name => 'capi5k-init', :size => "#{XP5K::Config[:nodes]}".to_i }),
   ],
 
   :command    => "sleep 206400"
 })
 
 $myxp.define_deployment({
-  :site           => "#{site}",
+  :site           => XP5K::Config[:site],
   :environment    => "ubuntu-x64-1204",
   :roles          => %w(capi5k-init),
-  :vlan_from_job  => "#{jobname}",
+  :vlan_from_job  => XP5K::Config[:jobname],
   :key            => File.read("#{ssh_public}"), 
 })
 

--- a/config/deploy/xp5k_common_roles.rb
+++ b/config/deploy/xp5k_common_roles.rb
@@ -15,9 +15,9 @@ end
 =end
 
 role :frontend do
-    "#{site}"
+    "#{XP5K::Config[:site]}"
 end
 
 role :subnet do
-    "#{site}"
+    "#{XP5K::Config[:site]}"
 end

--- a/config/lib/vlan.rb
+++ b/config/lib/vlan.rb
@@ -4,7 +4,7 @@ def translate_vlan(nodes, jobname = "-1")
   end
 
   # get vlan number using the jobname variable
-  vlan = $myxp.job_with_name("#{jobname}")['resources_by_type']['vlans'].first
+  vlan = $myxp.job_with_name("#{XP5K::Config[:jobname]}")['resources_by_type']['vlans'].first
 
   to_translate = nodes
   puts to_translate.inspect

--- a/exports/capi5k-puppetcluster/roles.rb
+++ b/exports/capi5k-puppetcluster/roles.rb
@@ -8,11 +8,11 @@
 #
 #
 def role_puppet_master
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').first, "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').first, "#{XP5K::Config[:jobname]}")
 end
 
 def role_puppet_clients
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{XP5K::Config[:jobname]}")
 end
 
 def puppet_version

--- a/recipe.rb
+++ b/recipe.rb
@@ -86,14 +86,14 @@ namespace :openstack do
       set :user, "#{g5k_user}"
 
       # get vlan number using the jobname variable
-      vlan = $myxp.job_with_name("#{jobname}")['resources_by_type']['vlans'].first.to_i
+      vlan = $myxp.job_with_name("#{XP5K::Config[:jobname]}")['resources_by_type']['vlans'].first.to_i
 
       case vlan
       when 1 .. 3
         puts "Non-routed local vlans not supported"
       when 4 .. 21
         vlan_config = YAML::load_file("#{openstack_path}/vlan-config.yaml")
-        ip=vlan_config["#{site}"][vlan]
+        ip=vlan_config["#{XP5K::Config[:site]}"][vlan]
         cidr =  NetAddr::CIDR.create(ip)
         splited_ip = cidr.first.split('.')
         # calculate gateway according to /18 subnet
@@ -291,10 +291,10 @@ namespace :openstack do
       controllerAddress = capture "facter ipaddress"
 
       # get vlan number using the jobname variable
-      vlan = $myxp.job_with_name("#{jobname}")['resources_by_type']['vlans'].first.to_i
+      vlan = $myxp.job_with_name("#{XP5K::Config[:jobname]}")['resources_by_type']['vlans'].first.to_i
       # get corresponding IP and add 30 to the c part to not collide with any host of g5k
       vlan_config = YAML::load_file("#{openstack_path}/vlan-config.yaml")
-      ip=vlan_config["#{site}"][vlan]
+      ip=vlan_config["#{XP5K::Config[:site]}"][vlan]
       cidr =  NetAddr::CIDR.create(ip)
       splited_ip = cidr.first.split('.')
       c=(splited_ip[2].to_i+30).to_s

--- a/roles.rb
+++ b/roles.rb
@@ -9,19 +9,19 @@
 #
 
 def role_controller
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{XP5K::Config[:jobname]}")
 end
 
 # TODO setting to another node seems to not validate a constraints when puppet agent runs
 def role_storage
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init')[1], "#{XP5K::Config[:jobname]}")
 end
 
 def role_compute
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(3..-1), "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(2..-1), "#{XP5K::Config[:jobname]}")
 end
 
 def role_openstack
-  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{jobname}")
+  translate_vlan($myxp.get_deployed_nodes('capi5k-init').slice(1..-1), "#{XP5K::Config[:jobname]}")
 end
 

--- a/roles_definition.rb
+++ b/roles_definition.rb
@@ -24,6 +24,6 @@ end
 
 
 role :frontend do
-  "#{site}"
+  "#{XP5K::Config[:site]}"
 end
 

--- a/xp.conf.sample
+++ b/xp.conf.sample
@@ -1,0 +1,17 @@
+## OAR jobs defaults
+# jobname and cluster are optional
+jobname         'openstack'
+site            'nancy'
+cluster         'graphene'
+walltime        '1:00:00'
+
+## number of nodes given to OpenStack
+# should be at least 3
+# 2 of them are use by different services
+# 1+ will be used for compute nodes
+nodes           6
+
+## vlantype values:
+# "kavlan"        - routed local vlan
+# "kavlan-global" - global vlan
+vlantype        'kavlan'


### PR DESCRIPTION
Here's the pull request for the xp.conf configuration file support. The tests are still in progress but a final answer should be given today. 

This pull request also contains a fix of the number of compute node (from the 2nd id instead of the 3rd). Don't know if it is better to separate into two different pull requests for a modification of only one digit... 

Another pull request will probably be raised in few days (week?) to add a support for `ssh_public`, `user` and the `gateway` variables in _xp.conf_ to avoid the need for the _connection.rb_ file. 
